### PR TITLE
Debug skipped terraform apply in deploy.L pipeline

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -60,6 +60,10 @@ jobs:
     outputs:
       approved: ${{ steps.approval.outputs.approved }}
     steps:
+    - name: Debug approval workflow
+      run: |
+        echo "Skip approval input: ${{ github.event.inputs.skip_approval }}"
+        echo "Running approval step..."
     - name: Wait for approval
       id: approval
       uses: trstringer/manual-approval@v1
@@ -73,7 +77,7 @@ jobs:
     name: Deploy to Dev
     uses: ./.github/workflows/terraform-deploy.yml
     needs: [validate, plan, wait-for-approval]
-    if: ${{ github.event.inputs.skip_approval || needs.wait-for-approval.outputs.approved == 'true' }}
+    if: ${{ always() && (github.event.inputs.skip_approval == 'true' || needs.wait-for-approval.outputs.approved == 'true') && needs.plan.result == 'success' }}
     with:
       environment: dev
       aws-region: ${{ vars.AWS_REGION }}

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -60,10 +60,6 @@ jobs:
     outputs:
       approved: ${{ steps.approval.outputs.approved }}
     steps:
-    - name: Debug approval workflow
-      run: |
-        echo "Skip approval input: ${{ github.event.inputs.skip_approval }}"
-        echo "Running approval step..."
     - name: Wait for approval
       id: approval
       uses: trstringer/manual-approval@v1

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -45,6 +45,11 @@ jobs:
     outputs:
       approved: ${{ steps.approval.outputs.approved }}
     steps:
+    - name: Debug approval workflow
+      run: |
+        echo "Production deployment approval process starting..."
+        echo "Commit message: ${{ github.event.head_commit.message }}"
+        echo "Plan result: ${{ needs.plan.result }}"
     - name: Wait for approval
       id: approval
       uses: trstringer/manual-approval@v1
@@ -58,7 +63,7 @@ jobs:
     name: Deploy to Production
     uses: ./.github/workflows/terraform-deploy.yml
     needs: [validate, plan, wait-for-approval]
-    if: contains(github.event.head_commit.message, '[deploy-prod]') && needs.wait-for-approval.outputs.approved == 'true'
+    if: ${{ always() && contains(github.event.head_commit.message, '[deploy-prod]') && needs.wait-for-approval.outputs.approved == 'true' && needs.plan.result == 'success' }}
     with:
       environment: prod
       aws-region: ${{ vars.AWS_REGION }}

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -45,11 +45,6 @@ jobs:
     outputs:
       approved: ${{ steps.approval.outputs.approved }}
     steps:
-    - name: Debug approval workflow
-      run: |
-        echo "Production deployment approval process starting..."
-        echo "Commit message: ${{ github.event.head_commit.message }}"
-        echo "Plan result: ${{ needs.plan.result }}"
     - name: Wait for approval
       id: approval
       uses: trstringer/manual-approval@v1

--- a/.github/workflows/deploy-qa.yml
+++ b/.github/workflows/deploy-qa.yml
@@ -42,10 +42,6 @@ jobs:
     outputs:
       approved: ${{ steps.approval.outputs.approved }}
     steps:
-    - name: Debug approval workflow
-      run: |
-        echo "QA deployment approval process starting..."
-        echo "Plan result: ${{ needs.plan.result }}"
     - name: Wait for approval
       id: approval
       uses: trstringer/manual-approval@v1

--- a/.github/workflows/deploy-qa.yml
+++ b/.github/workflows/deploy-qa.yml
@@ -42,6 +42,10 @@ jobs:
     outputs:
       approved: ${{ steps.approval.outputs.approved }}
     steps:
+    - name: Debug approval workflow
+      run: |
+        echo "QA deployment approval process starting..."
+        echo "Plan result: ${{ needs.plan.result }}"
     - name: Wait for approval
       id: approval
       uses: trstringer/manual-approval@v1
@@ -55,7 +59,7 @@ jobs:
     name: Deploy to QA
     uses: ./.github/workflows/terraform-deploy.yml
     needs: [validate, plan, wait-for-approval]
-    if: needs.wait-for-approval.outputs.approved == 'true'
+    if: ${{ always() && needs.wait-for-approval.outputs.approved == 'true' && needs.plan.result == 'success' }}
     with:
       environment: qa
       aws-region: ${{ vars.AWS_REGION }}

--- a/.github/workflows/terraform-deploy.yml
+++ b/.github/workflows/terraform-deploy.yml
@@ -53,6 +53,15 @@ jobs:
         name: terraform-plan-${{ inputs.environment }}
         path: .
       
+    - name: Debug plan file
+      run: |
+        echo "Plan file input: '${{ inputs.plan-file }}'"
+        echo "Expected plan file: terraform-plan-${{ inputs.environment }}.tfplan"
+        echo "Current directory contents:"
+        ls -la
+        echo "Checking for plan files:"
+        find . -name "*.tfplan" -type f || echo "No .tfplan files found"
+        
     - name: Deploy to ${{ inputs.environment }} environment
       run: |
         if [ -f "${{ inputs.plan-file }}" ]; then

--- a/.github/workflows/terraform-deploy.yml
+++ b/.github/workflows/terraform-deploy.yml
@@ -52,15 +52,6 @@ jobs:
       with:
         name: terraform-plan-${{ inputs.environment }}
         path: .
-      
-    - name: Debug plan file
-      run: |
-        echo "Plan file input: '${{ inputs.plan-file }}'"
-        echo "Expected plan file: terraform-plan-${{ inputs.environment }}.tfplan"
-        echo "Current directory contents:"
-        ls -la
-        echo "Checking for plan files:"
-        find . -name "*.tfplan" -type f || echo "No .tfplan files found"
         
     - name: Deploy to ${{ inputs.environment }} environment
       run: |

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -47,10 +47,9 @@ jobs:
       id: plan
       run: |
         ./scripts/build.sh plan ${{ inputs.environment }}
-        # Ensure the plan file exists in the expected location
+        # Validate plan file was generated successfully
         if [ -f "terraform-plan-${{ inputs.environment }}.tfplan" ]; then
           echo "plan-file=terraform-plan-${{ inputs.environment }}.tfplan" >> $GITHUB_OUTPUT
-          echo "Plan file generated successfully: terraform-plan-${{ inputs.environment }}.tfplan"
         else
           echo "Error: Plan file not generated"
           exit 1

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -47,7 +47,14 @@ jobs:
       id: plan
       run: |
         ./scripts/build.sh plan ${{ inputs.environment }}
-        echo "plan-file=terraform-plan-${{ inputs.environment }}.tfplan" >> $GITHUB_OUTPUT
+        # Ensure the plan file exists in the expected location
+        if [ -f "terraform-plan-${{ inputs.environment }}.tfplan" ]; then
+          echo "plan-file=terraform-plan-${{ inputs.environment }}.tfplan" >> $GITHUB_OUTPUT
+          echo "Plan file generated successfully: terraform-plan-${{ inputs.environment }}.tfplan"
+        else
+          echo "Error: Plan file not generated"
+          exit 1
+        fi
       
     - name: Upload plan file
       uses: actions/upload-artifact@v4

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -155,11 +155,16 @@ plan_terraform() {
     if [ -f "workspace.sh" ]; then
         chmod +x workspace.sh
         ./workspace.sh plan "$env"
+        # The workspace script now creates the plan file in the correct location
+        print_status "Plan saved to terraform-plan-${env}.tfplan"
     else
-        # Manual workspace management
+        # Manual workspace management with consistent plan file naming
         terraform workspace select "$env" || terraform workspace new "$env"
-        terraform plan -out=plan.out
-        print_status "Plan saved to terraform/plan.out"
+        local plan_file="terraform-plan-${env}.tfplan"
+        terraform plan -out="$plan_file"
+        # Copy plan file to parent directory for CI/CD pipeline
+        cp "$plan_file" "../$plan_file"
+        print_status "Plan saved to $plan_file and copied to parent directory"
     fi
     
     cd ..
@@ -189,21 +194,36 @@ apply_terraform() {
     # Use workspace script if available
     if [ -f "workspace.sh" ]; then
         chmod +x workspace.sh
+        # Select the correct workspace first
+        terraform workspace select "$env" || terraform workspace new "$env"
+        
         if [ -n "$plan_file" ] && [ -f "../$plan_file" ]; then
             print_status "Applying saved plan from $plan_file"
-            terraform workspace select "$env" || terraform workspace new "$env"
             terraform apply "../$plan_file"
+        elif [ -n "$plan_file" ] && [ -f "$plan_file" ]; then
+            print_status "Applying saved plan from $plan_file (local path)"
+            terraform apply "$plan_file"
+        elif [ -f "terraform-plan-${env}.tfplan" ]; then
+            print_status "Applying saved plan from terraform-plan-${env}.tfplan"
+            terraform apply "terraform-plan-${env}.tfplan"
         else
+            print_status "No saved plan found, running full apply"
             ./workspace.sh apply "$env"
         fi
     else
         # Manual workspace management
         terraform workspace select "$env" || terraform workspace new "$env"
         
-        # Check if plan file exists
+        # Check if plan file exists (prioritize passed plan file)
         if [ -n "$plan_file" ] && [ -f "../$plan_file" ]; then
             print_status "Applying saved plan from $plan_file"
             terraform apply "../$plan_file"
+        elif [ -n "$plan_file" ] && [ -f "$plan_file" ]; then
+            print_status "Applying saved plan from $plan_file (local path)"
+            terraform apply "$plan_file"
+        elif [ -f "terraform-plan-${env}.tfplan" ]; then
+            print_status "Applying saved plan from terraform-plan-${env}.tfplan"
+            terraform apply "terraform-plan-${env}.tfplan"
         elif [ -f "plan.out" ]; then
             print_status "Applying saved plan from plan.out"
             terraform apply plan.out

--- a/terraform/workspace.sh
+++ b/terraform/workspace.sh
@@ -128,7 +128,16 @@ plan_changes() {
     fi
     
     print_status "Running terraform plan..."
-    terraform plan
+    # Generate plan file for CI/CD pipeline
+    local plan_file="terraform-plan-${env}.tfplan"
+    terraform plan -out="$plan_file"
+    
+    # Also copy to the expected location for build script compatibility
+    if [[ -f "$plan_file" ]]; then
+        cp "$plan_file" "../$plan_file"
+        print_status "Plan file saved as: $plan_file"
+        print_status "Plan file copied to parent directory for CI/CD pipeline"
+    fi
 }
 
 # Function to apply changes


### PR DESCRIPTION
Fixes CI/CD pipeline to prevent Terraform `apply` step from being skipped by correcting plan file handling and workflow conditions.

The `terraform apply` step was being skipped because the plan file was not consistently generated, named, or passed correctly between jobs, and the conditional logic in the deploy workflows was not robust enough to trigger the `apply` step after manual approval. This PR ensures proper plan file management and updates workflow conditions.

---

[Open in Web](https://cursor.com/agents?id=bc-1891cd31-b5c4-4cb6-bf9c-67004217a061) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-1891cd31-b5c4-4cb6-bf9c-67004217a061) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)