### PR TITLE
Fix terraform ci/cd deploy-dev.yml

### DIFF
--- a/.github/workflows/terraform-deploy.yml
+++ b/.github/workflows/terraform-deploy.yml
@@ -69,8 +69,8 @@ jobs:
     - name: Deploy to ${{ inputs.environment }} environment
       run: |
         if [ -f "terraform/terraform-plan-${{ inputs.environment }}.tfplan" ]; then
-          echo "Applying saved plan file: terraform/terraform-plan-${{ inputs.environment }}.tfplan"
-          ./scripts/build.sh apply ${{ inputs.environment }} terraform/terraform-plan-${{ inputs.environment }}.tfplan
+          echo "Applying saved plan file: terraform-plan-${{ inputs.environment }}.tfplan"
+          ./scripts/build.sh apply ${{ inputs.environment }} terraform-plan-${{ inputs.environment }}.tfplan
         else
           echo "No plan file found, running full deploy"
           ./scripts/build.sh deploy ${{ inputs.environment }}

--- a/.github/workflows/terraform-deploy.yml
+++ b/.github/workflows/terraform-deploy.yml
@@ -53,14 +53,18 @@ jobs:
       uses: actions/download-artifact@v4
       with:
         name: terraform-plan-${{ inputs.environment }}
-        path: terraform/terraform-plan-${{ inputs.environment }}.tfplan
+        path: terraform/
       
-    - name: Download plan file
-      if: inputs.plan-file != ''
-      uses: actions/download-artifact@v4
-      with:
-        name: terraform-plan-${{ inputs.environment }}
-        path: .
+    - name: Verify plan file exists
+      run: |
+        if [ -f "terraform/terraform-plan-${{ inputs.environment }}.tfplan" ]; then
+          echo "Plan file found: terraform/terraform-plan-${{ inputs.environment }}.tfplan"
+          ls -la terraform/terraform-plan-${{ inputs.environment }}.tfplan
+        else
+          echo "Plan file not found at expected location"
+          echo "Contents of terraform directory:"
+          ls -la terraform/
+        fi
         
     - name: Deploy to ${{ inputs.environment }} environment
       run: |


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Fix duplicate download steps and incorrect artifact path in `terraform-deploy.yml` to resolve CI/CD pipeline issues.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The `terraform-deploy.yml` workflow had two steps named "Download plan file" with conflicting logic and an incorrect path for `actions/download-artifact@v4`, which expects a directory. This PR removes the redundant step, corrects the download path to a directory, and adds a verification step to ensure the plan file is correctly downloaded and located.

---
<a href="https://cursor.com/background-agent?bcId=bc-be16ef87-1949-4e18-ba9e-4392144512b5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-be16ef87-1949-4e18-ba9e-4392144512b5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>